### PR TITLE
Update find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -18,15 +19,20 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all internships whose company names contain any"
-            + " of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + " of the specified name, role, status and tag keywords and displays them as a list with index numbers.\n"
             + "Parameters: "
-            + "[" + PREFIX_COMPANY_NAME + "NAME_KEYWORD]"
-            + "[" + PREFIX_STATUS + "STATUS_KEYWORD]"
+            + "[" + PREFIX_COMPANY_NAME + "NAME_KEYWORD]... "
+            + "[" + PREFIX_ROLE + "ROLE_KEYWORD]... "
+            + "[" + PREFIX_STATUS + "STATUS_KEYWORD]... "
             + "[" + PREFIX_TAG + "TAG_KEYWORD]...\n"
             + "Example: " + COMMAND_WORD
-            + PREFIX_COMPANY_NAME + "apple google facebook"
-            + PREFIX_STATUS + "applied interview offered"
-            + PREFIX_TAG + "python"
+            + PREFIX_COMPANY_NAME + "apple "
+            + PREFIX_COMPANY_NAME + "google "
+            + PREFIX_ROLE + "software "
+            + PREFIX_ROLE + "developer "
+            + PREFIX_STATUS + "applied "
+            + PREFIX_STATUS + "offered "
+            + PREFIX_TAG + "python "
             + PREFIX_TAG + "java";
 
     private final InternshipContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -80,14 +80,6 @@ public class FindCommandParser implements Parser<FindCommand> {
     }
 
     private List<String> split(List<String> ls) throws ParseException {
-        //check if should throw this ParseException
-        for (String str : ls) {
-            if (str.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-        }
-
         return ls.stream()
                 .map(str -> str.split("\\s+"))
                 .flatMap(arr -> Arrays.asList(arr).stream())

--- a/src/main/java/seedu/address/model/internship/InternshipContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/internship/InternshipContainsKeywordsPredicate.java
@@ -10,6 +10,7 @@ import seedu.address.commons.util.StringUtil;
  */
 public class InternshipContainsKeywordsPredicate implements Predicate<Internship> {
     private final List<String> nameKeywords;
+    private final List<String> roleKeywords;
     private final List<String> statusKeywords;
     private final List<String> tagKeywords;
 
@@ -18,9 +19,10 @@ public class InternshipContainsKeywordsPredicate implements Predicate<Internship
      *
      * @param nameKeywords The keywords to check for in the Internship's company name.
      */
-    public InternshipContainsKeywordsPredicate(List<String> nameKeywords, List<String> statusKeywords,
-                                               List<String> tagKeywords) {
+    public InternshipContainsKeywordsPredicate(List<String> nameKeywords, List<String> roleKeywords,
+                                               List<String> statusKeywords, List<String> tagKeywords) {
         this.nameKeywords = nameKeywords;
+        this.roleKeywords = roleKeywords;
         this.statusKeywords = statusKeywords;
         this.tagKeywords = tagKeywords;
     }
@@ -34,14 +36,16 @@ public class InternshipContainsKeywordsPredicate implements Predicate<Internship
     @Override
     public boolean test(Internship internship) {
         boolean noNameKeywords = this.nameKeywords.isEmpty();
+        boolean noRoleKeywords = this.roleKeywords.isEmpty();
         boolean noStatusKeywords = this.statusKeywords.isEmpty();
         boolean noTagKeywords = this.tagKeywords.isEmpty();
 
-        if (noNameKeywords && noStatusKeywords && noTagKeywords) {
+        if (noNameKeywords && noRoleKeywords && noStatusKeywords && noTagKeywords) {
             return false;
         }
 
         boolean nameCheck = true;
+        boolean roleCheck = true;
         boolean statusCheck = true;
         boolean tagCheck = true;
 
@@ -49,6 +53,12 @@ public class InternshipContainsKeywordsPredicate implements Predicate<Internship
             nameCheck = this.nameKeywords.stream()
                     .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                             internship.getCompanyName().fullCompanyName, keyword));
+        }
+
+        if (!noRoleKeywords) {
+            roleCheck = this.roleKeywords.stream()
+                    .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                            internship.getRole().fullRole, keyword));
         }
 
         if (!noStatusKeywords) {
@@ -64,7 +74,7 @@ public class InternshipContainsKeywordsPredicate implements Predicate<Internship
                             .anyMatch(tagName -> StringUtil.containsWordIgnoreCase(keyword, tagName)));
         }
 
-        return nameCheck && statusCheck && tagCheck;
+        return nameCheck && roleCheck && statusCheck && tagCheck;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -124,6 +124,7 @@ public class CommandTestUtil {
 
         Internship internship = model.getFilteredInternshipList().get(targetIndex.getZeroBased());
         final String[] splitCompanyName = internship.getCompanyName().fullCompanyName.split("\\s+");
+        final String[] splitRole = internship.getRole().fullRole.split("\\s+");
         final String[] splitStatus = internship.getStatus().fullStatus.split("\\s+");
         final String[] splitTag = internship.getTags().isEmpty()
                 ? new String[0]
@@ -132,7 +133,8 @@ public class CommandTestUtil {
                         .map(str -> str.split("\\s+"))
                         .findFirst().get();
         model.updateFilteredInternshipList(new InternshipContainsKeywordsPredicate(
-                Arrays.asList(splitCompanyName[0]), Arrays.asList(splitStatus[0]), Arrays.asList((splitTag[0]))));
+                Arrays.asList(splitCompanyName[0]), Arrays.asList(splitRole[0]), Arrays.asList(splitStatus[0]),
+                Arrays.asList((splitTag[0]))));
 
         assertEquals(1, model.getFilteredInternshipList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -31,10 +31,12 @@ public class FindCommandTest {
     public void equals() {
         InternshipContainsKeywordsPredicate firstPredicate =
                 new InternshipContainsKeywordsPredicate(Collections.singletonList("first"),
-                        Collections.singletonList("first"), Collections.singletonList("first"));
+                        Collections.singletonList("first"), Collections.singletonList("first"),
+                        Collections.singletonList("first"));
         InternshipContainsKeywordsPredicate secondPredicate =
                 new InternshipContainsKeywordsPredicate(Collections.singletonList("second"),
-                        Collections.singletonList("second"), Collections.singletonList("second"));
+                        Collections.singletonList("second"), Collections.singletonList("second"),
+                        Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -61,7 +63,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_INTERNSHIP_LISTED_OVERVIEW, 0);
         InternshipContainsKeywordsPredicate predicate =
                 new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
-                        Collections.emptyList());
+                        Collections.emptyList(), Collections.emptyList());
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredInternshipList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -73,7 +75,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_INTERNSHIP_LISTED_OVERVIEW, 3);
         InternshipContainsKeywordsPredicate predicate =
                 new InternshipContainsKeywordsPredicate(Arrays.asList("Goldman", "Riot", "Samsung"),
-                        Collections.emptyList(), Collections.emptyList());
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredInternshipList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -75,15 +76,18 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
+        List<String> roleKeywords = Arrays.asList("blah", "haha");
         List<String> statusKeywords = Arrays.asList("new");
         List<String> tagKeywords = Arrays.asList("boo");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD
                         + " " + PREFIX_COMPANY_NAME + nameKeywords.stream().collect(Collectors.joining(" "))
+                        + " " + PREFIX_ROLE + roleKeywords.stream().collect(Collectors.joining(" "))
                         + " " + PREFIX_STATUS + statusKeywords.stream().collect(Collectors.joining(" "))
                         + " " + PREFIX_TAG + tagKeywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(
-                new InternshipContainsKeywordsPredicate(nameKeywords, statusKeywords, tagKeywords)), command);
+                new InternshipContainsKeywordsPredicate(nameKeywords, roleKeywords, statusKeywords, tagKeywords)),
+                command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,10 +4,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STATUS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BACK;
@@ -24,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.InternshipContainsKeywordsPredicate;
+import seedu.address.model.internship.Role;
 import seedu.address.model.internship.Status;
 import seedu.address.model.tag.Tag;
 
@@ -42,41 +46,37 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Google"),
-                        Arrays.asList("applied"),
-                        Arrays.asList("frontend")));
+                        Arrays.asList("software", "developer"), Arrays.asList("applied"), Arrays.asList("frontend")));
 
-        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + STATUS_DESC_GOOGLE + TAG_DESC_FRONT,
-                expectedFindCommand);
+        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                        + TAG_DESC_FRONT, expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n " + COMPANY_NAME_DESC_GOOGLE + " \n \t "
+        assertParseSuccess(parser, " \n " + COMPANY_NAME_DESC_GOOGLE + " \n \t " + ROLE_DESC_GOOGLE + "\n "
                         + STATUS_DESC_GOOGLE + "  \t" + TAG_DESC_FRONT + "   \n\t", expectedFindCommand);
     }
 
     @Test
     public void parse_allFieldsPresent_success() {
         FindCommand expectedFindCommand =
-                new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Google"),
-                        Arrays.asList("applied"),
-                        Arrays.asList("backend", "frontend")));
+                new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Google", "Apple"),
+                        Arrays.asList("mobile", "developer", "software", "developer"),
+                        Arrays.asList("applied", "interview"), Arrays.asList("backend", "frontend")));
 
         // whitespace only preamble (Note: List of strings for tags in expectedFindCommand must be in
         // alphabetic and numeric order. This is because parseTags in FindCommandParser uses a HashSet which
         // automatically orders everything. That's why assetParseSuccess still passes even though the sequence
         // is TAG_DESC_FRONT followed by TAG_DESC_BACK.
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + COMPANY_NAME_DESC_GOOGLE
-                + STATUS_DESC_GOOGLE + TAG_DESC_FRONT + TAG_DESC_BACK, expectedFindCommand);
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + COMPANY_NAME_DESC_GOOGLE + COMPANY_NAME_DESC_APPLE
+                + ROLE_DESC_GOOGLE + ROLE_DESC_APPLE + STATUS_DESC_GOOGLE + STATUS_DESC_APPLE + TAG_DESC_FRONT
+                + TAG_DESC_BACK, expectedFindCommand);
 
-        // multiple company names - last company name accepted
-        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + COMPANY_NAME_DESC_GOOGLE
-                + STATUS_DESC_GOOGLE + TAG_DESC_FRONT + TAG_DESC_BACK, expectedFindCommand);
-
-        // multiple statuses - last status accepted
-        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + STATUS_DESC_APPLE + STATUS_DESC_GOOGLE
-                + TAG_DESC_FRONT + TAG_DESC_BACK, expectedFindCommand);
-
+        // multiple company names - all company names accepted
+        // multiple roles - all roles accepted
+        // multiple statuses - all statuses accepted
         // multiple tags - all accepted
-        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + STATUS_DESC_GOOGLE + TAG_DESC_FRONT
+        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                + COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE + TAG_DESC_FRONT
                 + TAG_DESC_BACK, expectedFindCommand);
     }
 
@@ -84,27 +84,31 @@ public class FindCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         FindCommand expectedFindCommand =
                 new FindCommand(new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                        Arrays.asList("interview"),
-                        Arrays.asList("frontend")));;
+                        Arrays.asList("mobile", "developer"), Arrays.asList("interview"), Arrays.asList("frontend")));
 
         // no name
-        assertParseSuccess(parser, STATUS_DESC_APPLE + TAG_DESC_FRONT, expectedFindCommand);
+        assertParseSuccess(parser, ROLE_DESC_APPLE + STATUS_DESC_APPLE + TAG_DESC_FRONT, expectedFindCommand);
+
+        // no role
+        expectedFindCommand =
+                new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Apple"), Collections.emptyList(),
+                        Arrays.asList("interview"), Arrays.asList("frontend")));
+
+        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + STATUS_DESC_APPLE + TAG_DESC_FRONT, expectedFindCommand);
 
         // no status
         expectedFindCommand =
                 new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Apple"),
-                        Collections.emptyList(),
-                        Arrays.asList("frontend")));
+                        Arrays.asList("mobile", "developer"), Collections.emptyList(), Arrays.asList("frontend")));
 
-        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + TAG_DESC_FRONT, expectedFindCommand);
+        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + TAG_DESC_FRONT, expectedFindCommand);
 
         // zero tags
         expectedFindCommand =
                 new FindCommand(new InternshipContainsKeywordsPredicate(Arrays.asList("Apple"),
-                        Arrays.asList("interview"),
-                        Collections.emptyList()));
+                        Arrays.asList("mobile", "developer"), Arrays.asList("interview"), Collections.emptyList()));
 
-        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + STATUS_DESC_APPLE, expectedFindCommand);
+        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE, expectedFindCommand);
     }
 
     @Test
@@ -118,24 +122,28 @@ public class FindCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid company name
-        assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + STATUS_DESC_GOOGLE + TAG_DESC_BACK
-                + TAG_DESC_FRONT, CompanyName.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                + TAG_DESC_BACK + TAG_DESC_FRONT, CompanyName.MESSAGE_CONSTRAINTS);
+
+        // invalid role
+        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + INVALID_ROLE_DESC + ROLE_DESC_GOOGLE
+                + TAG_DESC_BACK + TAG_DESC_FRONT, Role.MESSAGE_CONSTRAINTS);
 
         // invalid status
-        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + INVALID_STATUS_DESC + TAG_DESC_BACK
-                + TAG_DESC_FRONT, Status.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + INVALID_STATUS_DESC
+                + TAG_DESC_BACK + TAG_DESC_FRONT, Status.MESSAGE_CONSTRAINTS);
 
         // invalid tag
-        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + STATUS_DESC_GOOGLE + INVALID_TAG_DESC
-                + VALID_TAG_FRONT, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                + INVALID_TAG_DESC + VALID_TAG_FRONT, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + STATUS_DESC_GOOGLE + INVALID_TAG_DESC,
-                CompanyName.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                        + INVALID_TAG_DESC, CompanyName.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + COMPANY_NAME_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                        + TAG_DESC_BACK + TAG_DESC_FRONT,
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE
+                        + STATUS_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -121,8 +121,7 @@ public class ModelManagerTest {
         // different filteredList -> returns false
         String[] keywords = APPLE.getCompanyName().fullCompanyName.split("\\s+");
         modelManager.updateFilteredInternshipList(new InternshipContainsKeywordsPredicate(Arrays.asList(keywords),
-                Collections.emptyList(),
-                Collections.emptyList()));
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/address/model/internship/InternshipContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/internship/InternshipContainsKeywordsPredicateTest.java
@@ -19,22 +19,19 @@ public class InternshipContainsKeywordsPredicateTest {
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
         InternshipContainsKeywordsPredicate firstPredicate =
-                new InternshipContainsKeywordsPredicate(firstPredicateKeywordList,
-                        firstPredicateKeywordList,
-                        firstPredicateKeywordList);
+                new InternshipContainsKeywordsPredicate(firstPredicateKeywordList, firstPredicateKeywordList,
+                        firstPredicateKeywordList, firstPredicateKeywordList);
         InternshipContainsKeywordsPredicate secondPredicate =
-                new InternshipContainsKeywordsPredicate(secondPredicateKeywordList,
-                        secondPredicateKeywordList,
-                        secondPredicateKeywordList);
+                new InternshipContainsKeywordsPredicate(secondPredicateKeywordList, secondPredicateKeywordList,
+                        secondPredicateKeywordList, secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
         InternshipContainsKeywordsPredicate firstPredicateCopy =
-                new InternshipContainsKeywordsPredicate(firstPredicateKeywordList,
-                        firstPredicateKeywordList,
-                        firstPredicateKeywordList);
+                new InternshipContainsKeywordsPredicate(firstPredicateKeywordList, firstPredicateKeywordList,
+                        firstPredicateKeywordList, firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -52,72 +49,83 @@ public class InternshipContainsKeywordsPredicateTest {
         // One name keyword
         InternshipContainsKeywordsPredicate predicate =
                 new InternshipContainsKeywordsPredicate(Collections.singletonList("Apple"),
-                        Collections.emptyList(),
-                        Collections.emptyList());
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertTrue(predicate.test(new InternshipBuilder().withCompanyName("Apple Google").build()));
 
         // Multiple name keywords
         predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("Apple", "Google"),
-                Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertTrue(predicate.test(new InternshipBuilder().withCompanyName("Apple Google").build()));
 
         // Only one matching name keyword
         predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("Google", "Grab"),
-                Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertTrue(predicate.test(new InternshipBuilder().withCompanyName("Apple Grab").build()));
 
         // Mixed-case name keywords
         predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("aPPle", "gOOGLE"),
-                Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertTrue(predicate.test(new InternshipBuilder().withCompanyName("Apple Google").build()));
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        // One status keyword
+        // One role keyword
         predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                        Collections.singletonList("applied"),
-                        Collections.emptyList());
-        assertTrue(predicate.test(new InternshipBuilder().withStatus("applied").build()));
+                Collections.singletonList("developer"), Collections.emptyList(), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withRole("developer").build()));
 
-        // Only one matching status keyword
+        // Multiple role keywords
         predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Arrays.asList("new", "applied"),
-                Collections.emptyList());
-        assertTrue(predicate.test(new InternshipBuilder().withStatus("applied").build()));
+                Arrays.asList("software", "developer"), Collections.emptyList(), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withRole("software developer").build()));
+
+        // Only one matching role keyword
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
+                Arrays.asList("developer", "engineer"), Collections.emptyList(), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withRole("software developer").build()));
 
         // Mixed-case status keyword
         predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Arrays.asList("oFFered", "reJECted"),
-                Collections.emptyList());
+                Arrays.asList("soFTwaRE", "dEVELOPer"), Collections.emptyList(), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withRole("software developer").build()));
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        // One status keyword
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Collections.singletonList("applied"), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withStatus("applied").build()));
+
+        // Only one matching status keyword
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList("new", "applied"), Collections.emptyList());
+        assertTrue(predicate.test(new InternshipBuilder().withStatus("applied").build()));
+
+        // Mixed-case status keyword
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList("oFFered", "reJECted"), Collections.emptyList());
         assertTrue(predicate.test(new InternshipBuilder().withStatus("offered").build()));
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////
 
         // One tag keyword
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.singletonList("python"));
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                        Collections.emptyList(), Collections.singletonList("python"));
         assertTrue(predicate.test(new InternshipBuilder().withTags("python", "java").build()));
 
         // Multiple tag keywords
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.emptyList(),
-                Arrays.asList("python", "java"));
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList("python", "java"));
         assertTrue(predicate.test(new InternshipBuilder().withTags("python", "java").build()));
 
         // Only one matching tag keyword
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.emptyList(),
-                Arrays.asList("python", "java"));
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList("python", "java"));
         assertTrue(predicate.test(new InternshipBuilder().withTags("python", "rust").build()));
 
         // Mixed-case tag keywords
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.emptyList(),
-                Arrays.asList("pYTHon", "jAVA"));
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList("pYTHon", "jAVA"));
         assertTrue(predicate.test(new InternshipBuilder().withTags("python", "java").build()));
     }
 
@@ -125,33 +133,28 @@ public class InternshipContainsKeywordsPredicateTest {
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         InternshipContainsKeywordsPredicate predicate =
-                new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList());
+                new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                        Collections.emptyList(), Collections.emptyList());
         assertFalse(predicate.test(new InternshipBuilder().withCompanyName("Apple").build()));
 
         // Non-matching name keyword
-        predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("Grab"),
-                Collections.emptyList(),
-                Collections.emptyList());
+        predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("Grab"), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList());
         assertFalse(predicate.test(new InternshipBuilder().withCompanyName("Apple Google").build()));
 
         // Non-matching status keyword
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Arrays.asList("new"),
-                Collections.emptyList());
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList("new"), Collections.emptyList());
         assertFalse(predicate.test(new InternshipBuilder().withStatus("rejected").build()));
 
         // Non-matching tag keyword
-        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.emptyList(),
-                Arrays.asList("python"));
+        predicate = new InternshipContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Arrays.asList("python"));
         assertFalse(predicate.test(new InternshipBuilder().withTags("java").build()));
 
         // Keywords match role, status and date, but does not match name
         predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("Developer", "applied", "2023-02-01"),
-                Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertFalse(predicate.test(new InternshipBuilder().withCompanyName("Apple").withRole("Developer")
                 .withStatus("applied").withDate("2023-02-01").build()));
     }


### PR DESCRIPTION
InternshipContainsKeywordsPredicate now takes in role keywords as well. Implementation for parsing name and role keywords have been changed to accomodate multiple name and role fields in find command.