### PR TITLE
Feature to include Comments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -57,7 +57,11 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_INTERNSHIP);
         }
 
+        //Add internship
         model.addInternship(toAdd);
+        //Update right panel
+        model.updateSelectedInternship(toAdd);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -24,12 +25,14 @@ public class AddCommand extends Command {
             + PREFIX_ROLE + "ROLE "
             + PREFIX_STATUS + "STATUS "
             + PREFIX_DATE + "DATE "
+            + "[" + PREFIX_COMMENT + "COMMENT] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_COMPANY_NAME + "Google "
             + PREFIX_ROLE + "Software Engineer "
             + PREFIX_STATUS + "applied "
             + PREFIX_DATE + "2023-02-01 "
+            + PREFIX_COMMENT + "I like the company culture "
             + PREFIX_TAG + "Go "
             + PREFIX_TAG + "Java";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -40,7 +40,13 @@ public class DeleteCommand extends Command {
         }
 
         Internship internshipToDelete = lastShownList.get(targetIndex.getZeroBased());
+        //Delete internship
         model.deleteInternship(internshipToDelete);
+        //Update right panel
+        if (internshipToDelete.equals(model.getSelectedInternship())) {
+            System.out.println("reached");
+            model.updateSelectedInternship(null);
+        }
         return new CommandResult(String.format(MESSAGE_DELETE_INTERNSHIP_SUCCESS, internshipToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -44,7 +44,6 @@ public class DeleteCommand extends Command {
         model.deleteInternship(internshipToDelete);
         //Update right panel
         if (internshipToDelete.equals(model.getSelectedInternship())) {
-            System.out.println("reached");
             model.updateSelectedInternship(null);
         }
         return new CommandResult(String.format(MESSAGE_DELETE_INTERNSHIP_SUCCESS, internshipToDelete));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -19,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -41,6 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_ROLE + "ROLE] "
             + "[" + PREFIX_STATUS + "STATUS] "
             + "[" + PREFIX_DATE + "DATE] "
+            + "[" + PREFIX_COMMENT + "COMMENT] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_ROLE + "Backend Engineer "
@@ -99,9 +102,11 @@ public class EditCommand extends Command {
         Role updatedRole = editInternshipDescriptor.getRole().orElse(internshipToEdit.getRole());
         Status updatedStatus = editInternshipDescriptor.getStatus().orElse(internshipToEdit.getStatus());
         Date updatedDate = editInternshipDescriptor.getDate().orElse(internshipToEdit.getDate());
+        Comment updatedComment = editInternshipDescriptor.getComment().orElse(internshipToEdit.getComment());
         Set<Tag> updatedTags = editInternshipDescriptor.getTags().orElse(internshipToEdit.getTags());
 
-        return new Internship(updatedCompanyName, updatedRole, updatedStatus, updatedDate, updatedTags);
+        return new Internship(updatedCompanyName, updatedRole, updatedStatus, updatedDate, updatedComment,
+                updatedTags);
     }
 
     @Override
@@ -131,6 +136,7 @@ public class EditCommand extends Command {
         private Role role;
         private Status status;
         private Date date;
+        private Comment comment;
         private Set<Tag> tags;
 
         public EditInternshipDescriptor() {}
@@ -144,6 +150,7 @@ public class EditCommand extends Command {
             setRole(toCopy.role);
             setStatus(toCopy.status);
             setDate(toCopy.date);
+            setComment(toCopy.comment);
             setTags(toCopy.tags);
         }
 
@@ -187,6 +194,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(date);
         }
 
+        public void setComment(Comment comment) {
+            this.comment = comment;
+        }
+
+        public Optional<Comment> getComment() {
+            return Optional.ofNullable(comment);
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -223,6 +238,7 @@ public class EditCommand extends Command {
                     && getRole().equals(e.getRole())
                     && getStatus().equals(e.getStatus())
                     && getDate().equals(e.getDate())
+                    && getComment().equals(e.getComment())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -158,7 +158,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(companyName, role, status, date, tags);
+            return CollectionUtil.isAnyNonNull(companyName, role, status, date, comment, tags);
         }
 
         public void setCompanyName(CompanyName companyName) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -84,8 +84,10 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_INTERNSHIP);
         }
 
+        //Edit functionality
         model.setInternship(internshipToEdit, editedInternship);
         model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+        model.updateSelectedInternship(editedInternship);
         return new CommandResult(String.format(MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship));
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -33,8 +34,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COMPANY_NAME, PREFIX_ROLE, PREFIX_STATUS, PREFIX_DATE,
-                        PREFIX_TAG);
-
+                        PREFIX_COMMENT, PREFIX_TAG);
+        //Note that comment and tags are optional
         if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY_NAME, PREFIX_ROLE, PREFIX_STATUS, PREFIX_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -44,9 +45,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Comment comment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Internship internship = new Internship(companyName, role, status, date, tagList);
+        Internship internship = new Internship(companyName, role, status, date, comment, tagList);
 
         return new AddCommand(internship);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -45,7 +45,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        Comment comment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get());
+        Comment comment = ParserUtil.parseComment(argMultimap.getOptionalValue(PREFIX_COMMENT).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Internship internship = new Internship(companyName, role, status, date, comment, tagList);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -40,6 +40,14 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns the last value of {@code prefix} for optional fields.
+     */
+    public Optional<String> getOptionalValue(Prefix prefix) {
+        List<String> values = getAllValues(prefix);
+        return values.isEmpty() ? Optional.of("NA") : Optional.of(values.get(values.size() - 1));
+    }
+
+    /**
      * Returns all values of {@code prefix}.
      * If the prefix does not exist or has no values, this will return an empty list.
      * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ROLE = new Prefix("r/");
     public static final Prefix PREFIX_STATUS = new Prefix("s/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_COMMENT = new Prefix("c/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
@@ -11,9 +12,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditInternshipDescriptor;
@@ -25,10 +29,21 @@ import seedu.address.model.tag.Tag;
  */
 public class EditCommandParser implements Parser<EditCommand> {
 
+
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     */
+
+    private static final Logger logger = LogsCenter.getLogger(EditCommandParser.class);
+
+    /**
+     * Parses arguments to construct an {@code EditCommand}
+     *
+     * @param args Raw user input.
+     * @return an {@code EditCommand} encapsulating the user's input.
+     * @throws ParseException if the user's input cannot be parsed into a valid {@code EditCommand}.
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -59,7 +74,20 @@ public class EditCommandParser implements Parser<EditCommand> {
             editInternshipDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
         if (argMultimap.getValue(PREFIX_COMMENT).isPresent()) {
-            editInternshipDescriptor.setComment(ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get()));
+            String commentContent = "";
+            try {
+                String userInput = argMultimap.getValue(PREFIX_COMMENT).get();
+                if (userInput.equals("")) {
+                    logger.info("User entered empty comment string, should reset comment to NA");
+                    commentContent = "NA";
+                } else {
+                    commentContent = userInput;
+                }
+            } catch (NoSuchElementException emptyComment) {
+                //Should not reach here
+                assert(false);
+            }
+            editInternshipDescriptor.setComment(ParserUtil.parseComment(commentContent));
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editInternshipDescriptor::setTags);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -58,6 +58,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             editInternshipDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
+        if (argMultimap.getValue(PREFIX_COMMENT).isPresent()) {
+            editInternshipDescriptor.setComment(ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get()));
+        }
+
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editInternshipDescriptor::setTags);
 
         if (!editInternshipDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -33,7 +34,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COMPANY_NAME, PREFIX_STATUS, PREFIX_ROLE, PREFIX_DATE,
-                        PREFIX_TAG);
+                        PREFIX_COMMENT, PREFIX_TAG);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -118,7 +118,7 @@ public class ParserUtil {
         }
         String trimmedComment = commentContent.trim();
         if (!Comment.isValidComment(trimmedComment)) {
-            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Comment.MESSAGE_CONSTRAINTS);
         }
         return new Comment(trimmedComment);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -113,9 +113,6 @@ public class ParserUtil {
      * @throws ParseException if the given {@code comment} is invalid.
      */
     public static Comment parseComment(String commentContent) throws ParseException {
-        if (commentContent == null) {
-            commentContent = "NA";
-        }
         String trimmedComment = commentContent.trim();
         if (!Comment.isValidComment(trimmedComment)) {
             throw new ParseException(Comment.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -113,7 +113,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code comment} is invalid.
      */
     public static Comment parseComment(String commentContent) throws ParseException {
-        requireNonNull(commentContent);
+        if (commentContent == null) {
+            commentContent = "NA";
+        }
         String trimmedComment = commentContent.trim();
         if (!Comment.isValidComment(trimmedComment)) {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Role;
@@ -39,6 +40,8 @@ public class ParserUtil {
      * Parses a {@code String companyName} into a {@code CompanyName}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param companyName The raw company name string.
+     * @return a {@CompanyName} object encapsulating the company name.
      * @throws ParseException if the given {@code companyName} is invalid.
      */
     public static CompanyName parseCompanyName(String companyName) throws ParseException {
@@ -51,10 +54,12 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String phone} into a {@code Phone}.
+     * Parses a {@code String role} into a {@code Role}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code phone} is invalid.
+     * @param role The raw role string to be parsed.
+     * @return the {@code Role} object encapsulating the role.
+     * @throws ParseException if the given {@code role} is invalid.
      */
     public static Role parseRole(String role) throws ParseException {
         requireNonNull(role);
@@ -69,6 +74,8 @@ public class ParserUtil {
      * Parses a {@code String status} into a {@code Status}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param status The raw status string to be parsed.
+     * @return the {@code Status} object encapsulating the status.
      * @throws ParseException if the given {@code status} is invalid.
      */
     public static Status parseStatus(String status) throws ParseException {
@@ -81,10 +88,12 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String email} into an {@code Email}.
+     * Parses a {@code String date} into an {@code Date}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code email} is invalid.
+     * @param date The raw date string to be parsed.
+     * @return the {@code Date} object encapsulating the date.
+     * @throws ParseException if the given {@code date} is invalid.
      */
     public static Date parseDate(String date) throws ParseException {
         requireNonNull(date);
@@ -96,9 +105,29 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String comment} into an {@code Comment}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param commentContent The raw comment to be parsed.
+     * @return a {@code Comment} object encapsulating the comment content.
+     * @throws ParseException if the given {@code comment} is invalid.
+     */
+    public static Comment parseComment(String commentContent) throws ParseException {
+        requireNonNull(commentContent);
+        String trimmedComment = commentContent.trim();
+        if (!Comment.isValidComment(trimmedComment)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Comment(trimmedComment);
+    }
+
+
+    /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param tag The raw tag string to be parsed.
+     * @return the {@code Tag} encapsulating the tag string.
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
@@ -112,6 +141,9 @@ public class ParserUtil {
 
     /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     *
+     * @param tags The collection of tag strings to be parsed.
+     * @return a set of {@code Tag} objects encapsulating the tag strings.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);

--- a/src/main/java/seedu/address/model/internship/Comment.java
+++ b/src/main/java/seedu/address/model/internship/Comment.java
@@ -1,0 +1,59 @@
+package seedu.address.model.internship;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a comment in InternBuddy.
+ * Guarantees: immutable; name is valid as declared in {@link #isValidComment(String)}
+ */
+public class Comment {
+
+    public static final String MESSAGE_CONSTRAINTS = "Comments should not blank.";
+    public static final String VALIDATION_REGEX = ".*";
+
+    public final String commentContent;
+
+    /**
+     * Constructs a {@code Comment}
+     *
+     * @param commentContent The string content of the comment
+     */
+    public Comment(String commentContent) {
+        requireNonNull(commentContent);
+        checkArgument(isValidComment(commentContent), MESSAGE_CONSTRAINTS);
+        this.commentContent = commentContent;
+    }
+
+    /**
+     * Returns true if a given string is valid content for a comment
+     *
+     * @param test The string to be tested for comment validity.
+     */
+    public static boolean isValidComment(String test) {
+        if (test.isEmpty() || !test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Comment // instanceof handles nulls
+                && commentContent.equals(((Comment) other).commentContent)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return commentContent.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + commentContent + ']';
+    }
+
+}

--- a/src/main/java/seedu/address/model/internship/CompanyName.java
+++ b/src/main/java/seedu/address/model/internship/CompanyName.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents an Internship's company name in InternBuddy
+ * Represents an Internship's company name in InternBuddy.
  * Guarantees: immutable; is valid as declared in {@link #isValidCompanyName(String)}
  */
 public class CompanyName {

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -137,15 +137,6 @@ public class Internship {
 
         Internship otherInternship = (Internship) other;
 
-        System.out.println(otherInternship.getCompanyName().equals(getCompanyName()));
-        System.out.println(otherInternship.getRole().equals(getRole()));
-        System.out.println(otherInternship.getStatus().equals(getStatus()));
-        System.out.println(otherInternship.getDate().equals(getDate()));
-        System.out.println(otherInternship.getComment().equals(getComment()));
-        System.out.println(otherInternship.getTags().equals(getTags()));
-
-
-
         return otherInternship.getCompanyName().equals(getCompanyName())
                 && otherInternship.getRole().equals(getRole())
                 && otherInternship.getStatus().equals(getStatus())
@@ -168,10 +159,11 @@ public class Internship {
                 .append(getRole())
                 .append("; Status: ")
                 .append(getStatus())
-                .append("; Comment: ")
-                .append(getComment())
                 .append("; Date: ")
-                .append(getDate());
+                .append(getDate())
+                .append("; Comment: ")
+                .append(getComment());
+
 
 
         Set<Tag> tags = getTags();

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -146,8 +146,6 @@ public class Internship {
 
 
 
-
-
         return otherInternship.getCompanyName().equals(getCompanyName())
                 && otherInternship.getRole().equals(getRole())
                 && otherInternship.getStatus().equals(getStatus())

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -136,6 +136,18 @@ public class Internship {
         }
 
         Internship otherInternship = (Internship) other;
+
+        System.out.println(otherInternship.getCompanyName().equals(getCompanyName()));
+        System.out.println(otherInternship.getRole().equals(getRole()));
+        System.out.println(otherInternship.getStatus().equals(getStatus()));
+        System.out.println(otherInternship.getDate().equals(getDate()));
+        System.out.println(otherInternship.getComment().equals(getComment()));
+        System.out.println(otherInternship.getTags().equals(getTags()));
+
+
+
+
+
         return otherInternship.getCompanyName().equals(getCompanyName())
                 && otherInternship.getRole().equals(getRole())
                 && otherInternship.getStatus().equals(getStatus())

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -38,7 +38,7 @@ public class Internship {
      * @param tags The set of tags associated with the Internship.
      */
     public Internship(CompanyName companyName, Role role, Status status, Date date, Comment comment, Set<Tag> tags) {
-        requireAllNonNull(companyName, role, status, date, comment, tags);
+        requireAllNonNull(companyName, role, status, date, tags);
         this.companyName = companyName;
         this.role = role;
         this.status = status;

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -23,6 +23,8 @@ public class Internship {
     private final Status status;
 
     private final Date date;
+
+    private final Comment comment;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
@@ -30,15 +32,18 @@ public class Internship {
      *
      * @param companyName The name of the company associated with the Internship.
      * @param role The role or job position associated with the Internship.
-     * @param status The status of the Internship application.
+     * @param status The status of the Internship entry.
+     * @param date The date of the Internship entry.
+     * @param comment The comment of the Internship entry.
      * @param tags The set of tags associated with the Internship.
      */
-    public Internship(CompanyName companyName, Role role, Status status, Date date, Set<Tag> tags) {
-        requireAllNonNull(companyName, role, status, date, tags);
+    public Internship(CompanyName companyName, Role role, Status status, Date date, Comment comment, Set<Tag> tags) {
+        requireAllNonNull(companyName, role, status, date, comment, tags);
         this.companyName = companyName;
         this.role = role;
         this.status = status;
         this.date = date;
+        this.comment = comment;
         this.tags.addAll(tags);
     }
 
@@ -76,6 +81,15 @@ public class Internship {
      */
     public Date getDate() {
         return date;
+    }
+
+    /**
+     * Gets the comment for the Internship entry.
+     *
+     * @return the comment associated with the Internship entry.
+     */
+    public Comment getComment() {
+        return comment;
     }
 
     /**
@@ -121,18 +135,19 @@ public class Internship {
             return false;
         }
 
-        Internship otherPerson = (Internship) other;
-        return otherPerson.getCompanyName().equals(getCompanyName())
-                && otherPerson.getRole().equals(getRole())
-                && otherPerson.getStatus().equals(getStatus())
-                && otherPerson.getDate().equals(getDate())
-                && otherPerson.getTags().equals(getTags());
+        Internship otherInternship = (Internship) other;
+        return otherInternship.getCompanyName().equals(getCompanyName())
+                && otherInternship.getRole().equals(getRole())
+                && otherInternship.getStatus().equals(getStatus())
+                && otherInternship.getDate().equals(getDate())
+                && otherInternship.getComment().equals(getComment())
+                && otherInternship.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(companyName, role, status, date, tags);
+        return Objects.hash(companyName, role, status, date, comment, tags);
     }
 
     @Override
@@ -143,8 +158,11 @@ public class Internship {
                 .append(getRole())
                 .append("; Status: ")
                 .append(getStatus())
+                .append("; Comment: ")
+                .append(getComment())
                 .append("; Date: ")
                 .append(getDate());
+
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Tag in the address book.
+ * Represents a tag in InternBuddy.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
@@ -28,6 +28,8 @@ public class Tag {
 
     /**
      * Returns true if a given string is a valid tag name.
+     *
+     * @param test The string to be tested for tag validity.
      */
     public static boolean isValidTagName(String test) {
         if (test.isEmpty() || !test.matches(VALIDATION_REGEX)) {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.InternBuddy;
 import seedu.address.model.ReadOnlyInternBuddy;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -20,17 +21,22 @@ public class SampleDataUtil {
     public static Internship[] getSampleInternships() {
         return new Internship[] {
             new Internship(new CompanyName("Apple"), new Role("iOS Developer"), new Status("applied"),
-                new Date("2023-02-01"), getTagSet("front")),
+                new Date("2023-02-01"), new Comment("My dream company!"), getTagSet("front")),
             new Internship(new CompanyName("Amazon"), new Role("Cloud Architect"), new Status("new"),
-                new Date("2023-02-02"), getTagSet("aws", "cloud services")),
+                new Date("2023-02-02"), new Comment("Need to research more on cloud technology."),
+                    getTagSet("aws", "cloud services")),
             new Internship(new CompanyName("Google"), new Role("Software Engineer"), new Status("assessment"),
-                new Date("2023-02-03"), getTagSet("golang", "backend")),
+                new Date("2023-02-03"), new Comment("Good company culture"),
+                    getTagSet("golang", "backend")),
             new Internship(new CompanyName("Samsung"), new Role("Android Developer"), new Status("interview"),
-                new Date("2023-02-02"), getTagSet("android", "mobile")),
+                new Date("2023-02-02"), new Comment("To compare with Apple again."),
+                    getTagSet("android", "mobile")),
             new Internship(new CompanyName("Grab"), new Role("Frontend Designer"), new Status("offered"),
-                new Date("2023-02-02"), getTagSet("react", "css")),
+                new Date("2023-02-02"), new Comment("Good benefits."),
+                    getTagSet("react", "css")),
             new Internship(new CompanyName("Facebook"), new Role("Backend Developer"), new Status("rejected"),
-                new Date("2023-02-02"), getTagSet("sql"))
+                new Date("2023-02-02"), new Comment("Rejected because I lack proficiency in SQL."),
+                    getTagSet("sql"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedInternship.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedInternship.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -28,19 +29,25 @@ class JsonAdaptedInternship {
     private final String role;
     private final String status;
     private final String date;
+    private final String comment;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonAdaptedInternship} with the given person details.
+     * Constructs a {@code JsonAdaptedInternship} with the given internship details.
      */
     @JsonCreator
     public JsonAdaptedInternship(@JsonProperty("companyName") String companyName, @JsonProperty("role") String role,
             @JsonProperty("status") String status, @JsonProperty("date") String date,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("comment") String comment, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.companyName = companyName;
         this.role = role;
         this.status = status;
         this.date = date;
+        if (comment != null) {
+            this.comment = comment;
+        } else {
+            this.comment = "NA";
+        }
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -54,6 +61,7 @@ class JsonAdaptedInternship {
         role = source.getRole().fullRole;
         status = source.getStatus().toString();
         date = source.getDate().fullDate;
+        comment = source.getComment().commentContent;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -103,7 +111,9 @@ class JsonAdaptedInternship {
         }
         final Date modelDate = new Date(date);
 
+        final Comment modelComment = new Comment(comment);
+
         final Set<Tag> modelTags = new HashSet<>(internshipTags);
-        return new Internship(modelCompanyName, modelRole, modelStatus, modelDate, modelTags);
+        return new Internship(modelCompanyName, modelRole, modelStatus, modelDate, modelComment, modelTags);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedInternship.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedInternship.java
@@ -43,10 +43,10 @@ class JsonAdaptedInternship {
         this.role = role;
         this.status = status;
         this.date = date;
-        if (comment != null) {
-            this.comment = comment;
+        if (comment == null) {
+            this.comment = "";
         } else {
-            this.comment = "NA";
+            this.comment = comment;
         }
         if (tagged != null) {
             this.tagged.addAll(tagged);
@@ -111,6 +111,10 @@ class JsonAdaptedInternship {
         }
         final Date modelDate = new Date(date);
 
+
+        if (!Comment.isValidComment(comment)) {
+            throw new IllegalValueException(Comment.MESSAGE_CONSTRAINTS);
+        }
         final Comment modelComment = new Comment(comment);
 
         final Set<Tag> modelTags = new HashSet<>(internshipTags);

--- a/src/main/java/seedu/address/ui/InternshipDetailsCard.java
+++ b/src/main/java/seedu/address/ui/InternshipDetailsCard.java
@@ -29,6 +29,7 @@ import seedu.address.model.internship.Internship;
  */
 public class InternshipDetailsCard extends UiPart<Region> {
     public static final String ROLE_LABEL = "Role: ";
+
     private static final String FXML = "InternshipDetailsCard.fxml";
 
     /**
@@ -50,6 +51,8 @@ public class InternshipDetailsCard extends UiPart<Region> {
     private Label role;
     @FXML
     private Label date;
+    @FXML
+    private Text comment;
     @FXML
     private FlowPane tags;
     @FXML
@@ -75,6 +78,12 @@ public class InternshipDetailsCard extends UiPart<Region> {
         //Add Date
         String dateLabel = InternshipCard.getDateLabel(internship.getStatus().toString());
         date.setText(dateLabel + internship.getDate().fullDate);
+
+        //Add Comment
+        comment.setText(internship.getComment().commentContent);
+        //@@author eugenetangkj-reused
+        //Reused with modifications from https://stackoverflow.com/questions/29315469/javafx-resize-text-with-window
+        comment.wrappingWidthProperty().bind(scene.widthProperty().multiply(0.4));
 
         //Add Tags
         internship.getTags().stream()

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -212,6 +212,8 @@ public class MainWindow extends UiPart<Stage> {
             internshipDetailsPanelPlaceholder.getChildren().clear();
             internshipDetailsPanelPlaceholder.getChildren().add(internshipDetailsCard.getRoot());
             internshipDetailsPanelPlaceholder.setAlignment(Pos.TOP_CENTER);
+        } else {
+            System.out.println("reached");
         }
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -8,9 +8,11 @@ import javafx.geometry.Pos;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -58,6 +60,12 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane statusbarPlaceholder;
     @FXML
     private ScrollPane rightPanel;
+    @FXML
+    private Text introOne;
+    @FXML
+    private Text introTwo;
+    @FXML
+    private ImageView introThree;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -75,6 +83,7 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
     }
 
     public Stage getPrimaryStage() {
@@ -208,12 +217,18 @@ public class MainWindow extends UiPart<Stage> {
     private void updateRightPanel() {
         Internship selectedInternship = logic.getSelectedInternship();
         if (selectedInternship != null) {
+            //Update with internship information
             internshipDetailsCard = new InternshipDetailsCard(selectedInternship, primaryStage.getScene());
             internshipDetailsPanelPlaceholder.getChildren().clear();
             internshipDetailsPanelPlaceholder.getChildren().add(internshipDetailsCard.getRoot());
             internshipDetailsPanelPlaceholder.setAlignment(Pos.TOP_CENTER);
         } else {
-            System.out.println("reached");
+            //Reset to original introduction information
+            internshipDetailsPanelPlaceholder.getChildren().clear();
+            internshipDetailsPanelPlaceholder.getChildren().add(introOne);
+            internshipDetailsPanelPlaceholder.getChildren().add(introTwo);
+            internshipDetailsPanelPlaceholder.getChildren().add(introThree);
+            internshipDetailsPanelPlaceholder.setAlignment(Pos.CENTER);
         }
     }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -377,4 +377,8 @@
     -fx-font-size: 14;
 }
 
+.commentField {
+    -fx-text-fill: blue;
+}
+
 

--- a/src/main/resources/view/InternshipDetailsCard.fxml
+++ b/src/main/resources/view/InternshipDetailsCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox fx:id="cardPane" prefHeight="232.0" prefWidth="300.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="cardPane" prefHeight="232.0" prefWidth="300.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane>
          <columnConstraints>

--- a/src/main/resources/view/InternshipDetailsCard.fxml
+++ b/src/main/resources/view/InternshipDetailsCard.fxml
@@ -10,9 +10,10 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox fx:id="cardPane" prefHeight="232.0" prefWidth="300.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="cardPane" prefHeight="232.0" prefWidth="300.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane>
          <columnConstraints>
@@ -52,6 +53,19 @@
                         <Insets left="10.0" top="10.0" />
                      </VBox.margin>
                   </Label>
+                  <Label styleClass="whiteLabel" text="Comment:">
+                     <VBox.margin>
+                        <Insets left="10.0" top="10.0" />
+                     </VBox.margin>
+                  </Label>
+                  <Text fx:id="comment" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="\$comment">
+                     <VBox.margin>
+                        <Insets left="10.0" top="10.0" />
+                     </VBox.margin>
+                     <font>
+                        <Font name="Segoe UI" size="14.0" />
+                     </font>
+                  </Text>
                </children>
             </VBox>
             <VBox alignment="TOP_RIGHT" prefHeight="102.0" prefWidth="130.0" GridPane.columnIndex="1">
@@ -85,7 +99,7 @@
                   </Label>
                </children>
             </HBox>
-            <Text fx:id="tips" styleClass="tipsText" strokeType="OUTSIDE" strokeWidth="0.0" text="\$tips" wrappingWidth="267.13671875">
+            <Text fx:id="tips" strokeType="OUTSIDE" strokeWidth="0.0" text="\$tips" wrappingWidth="267.13671875">
                <VBox.margin>
                   <Insets bottom="10.0" top="10.0" />
                </VBox.margin>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -19,7 +19,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="700.0" minWidth="1000.0" onCloseRequest="#handleExit" title="InternBuddy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="700.0" minWidth="1000.0" onCloseRequest="#handleExit" title="InternBuddy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -72,7 +72,7 @@
                            <children>
                               <StackPane fx:id="internshipDetailsPanelPlaceholder" layoutX="11.0" style="-fx-background-color: #383838;" AnchorPane.bottomAnchor="8.0" AnchorPane.leftAnchor="9.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                  <children>
-                                    <Text fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="Welcome to InternBuddy" textAlignment="CENTER">
+                                    <Text fx:id="introOne" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="Welcome to InternBuddy" textAlignment="CENTER">
                                        <font>
                                           <Font name="Segoe UI Light" size="20.0" />
                                        </font>
@@ -80,7 +80,7 @@
                                           <Insets bottom="300.0" />
                                        </StackPane.margin>
                                     </Text>
-                                    <Text fill="WHITE" lineSpacing="15.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Feeling worried about managing your internships?&#10;InternBuddy is here to save the day!&#10;Whether it is tracking internships or providing reminders&#10;of upcoming deadlines, InternBuddy can do it all." textAlignment="CENTER">
+                                    <Text fx:id="introTwo" fill="WHITE" lineSpacing="15.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Feeling worried about managing your internships?&#10;InternBuddy is here to save the day!&#10;Whether it is tracking internships or providing reminders&#10;of upcoming deadlines, InternBuddy can do it all." textAlignment="CENTER">
                                        <font>
                                           <Font name="Segoe UI Light" size="16.0" />
                                        </font>
@@ -88,7 +88,7 @@
                                           <Insets bottom="100.0" />
                                        </StackPane.margin>
                                     </Text>
-                                    <ImageView fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
+                                    <ImageView fx:id="introThree" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
                                        <image>
                                           <Image url="@../../../../docs/images/internbuddy-hero.png" />
                                        </image>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -19,7 +19,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="700.0" minWidth="1000.0" onCloseRequest="#handleExit" title="InternBuddy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="700.0" minWidth="1000.0" onCloseRequest="#handleExit" title="InternBuddy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/test/data/JsonSerializableInternBuddyTest/duplicateInternshipInternBuddy.json
+++ b/src/test/data/JsonSerializableInternBuddyTest/duplicateInternshipInternBuddy.json
@@ -4,14 +4,14 @@
     "role": "Software Engineer",
     "status": "applied",
     "date": "2023-02-01",
-    "comment": [ "My dream company" ],
+    "comment": "My dream company",
     "tagged": [ "Go" ]
   }, {
     "companyName": "Google",
     "role": "Software Engineer",
     "status": "applied",
     "date": "2023-02-01",
-    "comment": [ "Not my dream company"],
+    "comment": "Not my dream company",
     "tagged": [ "Java" ]
   } ]
 }

--- a/src/test/data/JsonSerializableInternBuddyTest/duplicateInternshipInternBuddy.json
+++ b/src/test/data/JsonSerializableInternBuddyTest/duplicateInternshipInternBuddy.json
@@ -4,12 +4,14 @@
     "role": "Software Engineer",
     "status": "applied",
     "date": "2023-02-01",
+    "comment": [ "My dream company" ],
     "tagged": [ "Go" ]
   }, {
     "companyName": "Google",
     "role": "Software Engineer",
     "status": "applied",
     "date": "2023-02-01",
+    "comment": [ "Not my dream company"],
     "tagged": [ "Java" ]
   } ]
 }

--- a/src/test/data/JsonSerializableInternBuddyTest/invalidInternshipInternBuddy.json
+++ b/src/test/data/JsonSerializableInternBuddyTest/invalidInternshipInternBuddy.json
@@ -4,6 +4,7 @@
     "role": "Software Engineer",
     "status": "applied",
     "date": "23rd January 2023",
+    "comment": "I love Google",
     "tagged": [ "Go" ]
   } ]
 }

--- a/src/test/data/JsonSerializableInternBuddyTest/typicalInternshipInternBuddy.json
+++ b/src/test/data/JsonSerializableInternBuddyTest/typicalInternshipInternBuddy.json
@@ -5,41 +5,45 @@
       "role" : "Cloud Architect",
       "status" : "assessment",
       "date" : "2023-02-01",
-      "comment": "I love Amazon",
+      "comment": "I love Amazon!",
       "tagged" : [ "aws", "back" ]
   }, {
     "companyName" : "Food Panda",
     "role" : "Back end Developer",
     "status" : "assessment",
+    "comment": "I love Food Panda!",
     "date" : "2023-02-02"
   }, {
     "companyName" : "Goldman",
     "role" : "Cyber Security Analyst",
     "status" : "offered",
+    "comment": "I love Goldman!",
     "date" : "2023-02-03"
   }, {
     "companyName" : "Grab",
     "role" : "Front end Engineer",
     "status" : "rejected",
+    "comment": "I love Grab!",
     "date" : "2023-02-04"
   }, {
     "companyName" : "Riot Games",
     "role" : "Game Client Developer",
     "status" : "interview",
     "date" : "2023-02-05",
-    "comment": "I love Riot Games",
+    "comment": "I love Riot Games!",
     "tagged" : [ "game", "developer" ]
   }, {
     "companyName" : "Samsung",
     "role" : "Android Developer",
     "status" : "applied",
+    "comment": "I love Samsung!",
     "date" : "2023-02-06"
   }, {
     "companyName" : "Supercell Games",
     "role" : "Game Designer",
     "status" : "new",
     "date" : "2023-02-07",
-    "comment": "I love Supercell Games",
+    "comment": "I love Supercell Games!",
     "tagged" : [ "design", "game" ]
   } ]
 }

--- a/src/test/data/JsonSerializableInternBuddyTest/typicalInternshipInternBuddy.json
+++ b/src/test/data/JsonSerializableInternBuddyTest/typicalInternshipInternBuddy.json
@@ -5,6 +5,7 @@
       "role" : "Cloud Architect",
       "status" : "assessment",
       "date" : "2023-02-01",
+      "comment": "I love Amazon",
       "tagged" : [ "aws", "back" ]
   }, {
     "companyName" : "Food Panda",
@@ -26,6 +27,7 @@
     "role" : "Game Client Developer",
     "status" : "interview",
     "date" : "2023-02-05",
+    "comment": "I love Riot Games",
     "tagged" : [ "game", "developer" ]
   }, {
     "companyName" : "Samsung",
@@ -37,6 +39,7 @@
     "role" : "Game Designer",
     "status" : "new",
     "date" : "2023-02-07",
+    "comment": "I love Supercell Games",
     "tagged" : [ "design", "game" ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTERNSHIP_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.COMMENT_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_APPLE;
@@ -80,7 +81,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE
-                + STATUS_DESC_APPLE + DATE_DESC_APPLE;
+                + STATUS_DESC_APPLE + DATE_DESC_APPLE + COMMENT_DESC_APPLE;
         Internship expectedInternship = new InternshipBuilder(APPLE).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addInternship(expectedInternship);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -163,7 +163,8 @@ public class AddCommandTest {
 
         @Override
         public void updateSelectedInternship(Internship target) {
-            throw new AssertionError("This method should not be called.");
+            //This will be called to update the right panel
+            assert(true);
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -63,7 +63,7 @@ public class CommandTestUtil {
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "23-02-02";
 
     // Comment cannot be empty
-    public static final String INVALID_COMMENT_DESC = " " + "";
+    public static final String INVALID_COMMENT_DESC = " " + PREFIX_COMMENT + "";
 
     // tag more than 30 characters
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -76,10 +76,10 @@ public class CommandTestUtil {
     static {
         DESC_APPLE = new EditInternshipDescriptorBuilder().withCompanyName(VALID_COMPANY_NAME_APPLE)
                 .withRole(VALID_ROLE_APPLE).withStatus(VALID_STATUS_APPLE).withDate(VALID_DATE_APPLE)
-                .withTags(VALID_TAG_FRONT).build();
+                .withComment(VALID_COMMENT_APPLE).withTags(VALID_TAG_FRONT).build();
         DESC_GOOGLE = new EditInternshipDescriptorBuilder().withCompanyName(VALID_COMPANY_NAME_GOOGLE)
                 .withRole(VALID_ROLE_GOOGLE).withStatus(VALID_STATUS_GOOGLE).withDate(VALID_DATE_GOOGLE)
-                .withTags(VALID_TAG_BACK, VALID_TAG_FRONT).build();
+                .withComment(VALID_COMMENT_GOOGLE).withTags(VALID_TAG_BACK, VALID_TAG_FRONT).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -34,6 +35,8 @@ public class CommandTestUtil {
     public static final String VALID_STATUS_GOOGLE = "applied";
     public static final String VALID_DATE_APPLE = "2023-02-01";
     public static final String VALID_DATE_GOOGLE = "2023-02-03";
+    public static final String VALID_COMMENT_APPLE = "I love Apple!";
+    public static final String VALID_COMMENT_GOOGLE = "I love Google!";
     public static final String VALID_TAG_FRONT = "frontend";
     public static final String VALID_TAG_BACK = "backend";
 
@@ -45,6 +48,8 @@ public class CommandTestUtil {
     public static final String STATUS_DESC_GOOGLE = " " + PREFIX_STATUS + VALID_STATUS_GOOGLE;
     public static final String DATE_DESC_APPLE = " " + PREFIX_DATE + VALID_DATE_APPLE;
     public static final String DATE_DESC_GOOGLE = " " + PREFIX_DATE + VALID_DATE_GOOGLE;
+    public static final String COMMENT_DESC_APPLE = " " + PREFIX_COMMENT + VALID_COMMENT_APPLE;
+    public static final String COMMENT_DESC_GOOGLE = " " + PREFIX_COMMENT + VALID_COMMENT_GOOGLE;
     public static final String TAG_DESC_FRONT = " " + PREFIX_TAG + VALID_TAG_FRONT;
     public static final String TAG_DESC_BACK = " " + PREFIX_TAG + VALID_TAG_BACK;
 
@@ -56,6 +61,10 @@ public class CommandTestUtil {
     public static final String INVALID_STATUS_DESC = " " + PREFIX_STATUS + "pending";
     // invalid date format where dates have to be yyyy-MM-dd
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "23-02-02";
+
+    // Comment cannot be empty
+    public static final String INVALID_COMMENT_DESC = " " + "";
+
     // tag more than 30 characters
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.COMMENT_DESC_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.COMMENT_DESC_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_GOOGLE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
@@ -49,40 +52,55 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE
-                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
+                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
         // multiple company names - last company name accepted
         assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE
-                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
+                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
         // multiple roles - last role accepted
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_APPLE + ROLE_DESC_GOOGLE
-                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
+                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
         // multiple statuses - last status accepted
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_APPLE
-                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
+                + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
         // multiple dates - last date accepted
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_APPLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
+                + DATE_DESC_APPLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
         // multiple comments - last comment accepted
+        assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                + DATE_DESC_APPLE + COMMENT_DESC_APPLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                new AddCommand(expectedInternship));
 
 
         // multiple tags - all accepted
         Internship expectedInternshipMultipleTags = new InternshipBuilder(GOOGLE)
                 .withTags(VALID_TAG_FRONT, VALID_TAG_BACK).build();
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, new AddCommand(expectedInternshipMultipleTags));
+                + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT,
+                new AddCommand(expectedInternshipMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
+        //zero comments
+        Internship expectedInternship = new InternshipBuilder(APPLE).withComment(null).build();
+        assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE
+                + DATE_DESC_APPLE + COMMENT_DESC_APPLE, new AddCommand(expectedInternship));
+
         // zero tags
-        Internship expectedInternship = new InternshipBuilder(APPLE).withTags().build();
+        expectedInternship = new InternshipBuilder(APPLE).withTags().build();
         assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE
                         + DATE_DESC_APPLE, new AddCommand(expectedInternship));
+
     }
 
     @Test
@@ -114,23 +132,28 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid company name
         assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, CompanyName.MESSAGE_CONSTRAINTS);
+                + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT,
+                CompanyName.MESSAGE_CONSTRAINTS);
 
         // invalid role
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + INVALID_ROLE_DESC + STATUS_DESC_GOOGLE
-                + DATE_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, Role.MESSAGE_CONSTRAINTS);
+                + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, Role.MESSAGE_CONSTRAINTS);
 
         // invalid status
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + INVALID_STATUS_DESC
-                + DATE_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, Status.MESSAGE_CONSTRAINTS);
+                + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, Status.MESSAGE_CONSTRAINTS);
 
         // invalid date
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + INVALID_DATE_DESC + TAG_DESC_BACK + TAG_DESC_FRONT, Date.MESSAGE_CONSTRAINTS);
+                + INVALID_DATE_DESC + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT, Date.MESSAGE_CONSTRAINTS);
+
+        // invalid comment
+        assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
+                + DATE_DESC_GOOGLE + INVALID_COMMENT_DESC + TAG_DESC_BACK + TAG_DESC_FRONT, Date.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_GOOGLE + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+                + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_COMPANY_NAME_DESC + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
@@ -138,7 +161,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE
-                        + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT,
+                        + STATUS_DESC_GOOGLE + DATE_DESC_GOOGLE + COMMENT_DESC_GOOGLE + TAG_DESC_BACK + TAG_DESC_FRONT,
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -67,6 +67,9 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
                 + DATE_DESC_APPLE + DATE_DESC_GOOGLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
 
+        // multiple comments - last comment accepted
+
+
         // multiple tags - all accepted
         Internship expectedInternshipMultipleTags = new InternshipBuilder(GOOGLE)
                 .withTags(VALID_TAG_FRONT, VALID_TAG_BACK).build();

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -35,6 +35,7 @@ import static seedu.address.testutil.TypicalInternships.GOOGLE;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -77,7 +78,7 @@ public class AddCommandParserTest {
 
         // multiple comments - last comment accepted
         assertParseSuccess(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_APPLE + COMMENT_DESC_APPLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
+                + DATE_DESC_GOOGLE + COMMENT_DESC_APPLE + COMMENT_DESC_GOOGLE + TAG_DESC_FRONT,
                 new AddCommand(expectedInternship));
 
 
@@ -92,14 +93,14 @@ public class AddCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         //zero comments
-        Internship expectedInternship = new InternshipBuilder(APPLE).withComment(null).build();
+        Internship expectedInternship = new InternshipBuilder(APPLE).withComment("NA").build();
         assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE
-                + DATE_DESC_APPLE + COMMENT_DESC_APPLE, new AddCommand(expectedInternship));
+                + DATE_DESC_APPLE + TAG_DESC_FRONT, new AddCommand(expectedInternship));
 
-        // zero tags
+        //zero tags
         expectedInternship = new InternshipBuilder(APPLE).withTags().build();
         assertParseSuccess(parser, COMPANY_NAME_DESC_APPLE + ROLE_DESC_APPLE + STATUS_DESC_APPLE
-                        + DATE_DESC_APPLE, new AddCommand(expectedInternship));
+                        + DATE_DESC_APPLE + COMMENT_DESC_APPLE, new AddCommand(expectedInternship));
 
     }
 
@@ -149,7 +150,8 @@ public class AddCommandParserTest {
 
         // invalid comment
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE
-                + DATE_DESC_GOOGLE + INVALID_COMMENT_DESC + TAG_DESC_BACK + TAG_DESC_FRONT, Date.MESSAGE_CONSTRAINTS);
+                + DATE_DESC_GOOGLE + INVALID_COMMENT_DESC + TAG_DESC_BACK + TAG_DESC_FRONT,
+                Comment.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, COMPANY_NAME_DESC_GOOGLE + ROLE_DESC_GOOGLE + STATUS_DESC_GOOGLE

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_GOOGLE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditInternshipDescriptor;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Role;
@@ -96,6 +98,9 @@ public class EditCommandParserTest {
         // valid role followed by invalid role. The test case for invalid role followed by valid role
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + ROLE_DESC_GOOGLE + INVALID_ROLE_DESC, Role.MESSAGE_CONSTRAINTS);
+
+        // invalid comment
+        assertParseFailure(parser, "1" + INVALID_COMMENT_DESC, Comment.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Internship} being edited,
         // parsing it together with a valid tag results in error

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_GOOGLE;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COMPANY_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
@@ -25,6 +24,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BACK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRONT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditInternshipDescriptor;
-import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Role;
@@ -47,7 +46,9 @@ import seedu.address.testutil.EditInternshipDescriptorBuilder;
 
 public class EditCommandParserTest {
 
+    private static final String COMMENT_EMPTY = " " + PREFIX_COMMENT;
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
+
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
@@ -99,8 +100,6 @@ public class EditCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + ROLE_DESC_GOOGLE + INVALID_ROLE_DESC, Role.MESSAGE_CONSTRAINTS);
 
-        // invalid comment
-        assertParseFailure(parser, "1" + INVALID_COMMENT_DESC, Comment.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Internship} being edited,
         // parsing it together with a valid tag results in error
@@ -218,5 +217,17 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_resetComment_success() {
+        Index targetIndex = INDEX_THIRD_INTERNSHIP;
+        String userInput = targetIndex.getOneBased() + COMMENT_EMPTY;
+
+        EditInternshipDescriptor descriptor = new EditInternshipDescriptorBuilder().withComment("NA").build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Role;
@@ -25,12 +26,14 @@ public class ParserUtilTest {
     private static final String INVALID_ROLE = "i@S Developer";
     private static final String INVALID_STATUS = "pending";
     private static final String INVALID_DATE = "23-02-01";
+    private static final String INVALID_COMMENT = "";
     private static final String INVALID_TAG = " ";
 
     private static final String VALID_COMPANY_NAME = "Apple";
     private static final String VALID_ROLE = "iOS Developer";
     private static final String VALID_STATUS = "applied";
     private static final String VALID_DATE = "2023-02-01";
+    private static final String VALID_COMMENT = "I love Apple!";
     private static final String VALID_TAG_1 = "front";
     private static final String VALID_TAG_2 = "back";
 
@@ -136,16 +139,39 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseDate_validValueWithoutWhitespace_returnsEmail() throws Exception {
+    public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
         Date expectedDate = new Date(VALID_DATE);
         assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
     }
 
     @Test
-    public void parseDate_validValueWithWhitespace_returnsTrimmedEmail() throws Exception {
+    public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
         String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
         Date expectedDate = new Date(VALID_DATE);
         assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
+    }
+
+    @Test
+    public void parseComment_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseComment((String) null));
+    }
+
+    @Test
+    public void parseComment_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseComment(INVALID_COMMENT));
+    }
+
+    @Test
+    public void parseComment_validValueWithoutWhitespace_returnsComment() throws Exception {
+        Comment expectedComment = new Comment(VALID_COMMENT);
+        assertEquals(expectedComment, ParserUtil.parseComment(VALID_COMMENT));
+    }
+
+    @Test
+    public void parseComment_validValueWithWhitespace_returnsTrimmedComment() throws Exception {
+        String commentWithWhitespace = WHITESPACE + VALID_COMMENT + WHITESPACE;
+        Comment expectedComment = new Comment(VALID_COMMENT);
+        assertEquals(expectedComment, ParserUtil.parseComment(commentWithWhitespace));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/internship/CommentTest.java
+++ b/src/test/java/seedu/address/model/internship/CommentTest.java
@@ -1,4 +1,62 @@
 package seedu.address.model.internship;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class CommentTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Comment(null));
+    }
+
+    @Test
+    public void constructor_invalidComment_throwsIllegalArgumentException() {
+        String invalidComment = "";
+        assertThrows(IllegalArgumentException.class, () -> new Comment(invalidComment));
+    }
+
+    @Test
+    public void isValidComment() {
+        //Invalid Comments
+        assertThrows(NullPointerException.class, () -> Comment.isValidComment(null));
+        assertFalse(Comment.isValidComment("")); // empty string
+
+        //Valid Comments
+        assertTrue(Comment.isValidComment("  hello")); //with leading white space
+        assertTrue(Comment.isValidComment("hello    ")); //with trailing white space
+        assertTrue(Comment.isValidComment("A1b2")); //alphanumeric
+        assertTrue(Comment.isValidComment("I love C#!_?")); //with symbols
+    }
+
+    @Test
+    public void checkCommentEquality() {
+        Comment commentOne = new Comment("hello");
+        Comment commentOneDuplicated = new Comment("hello");
+        Comment commentTwo = new Comment("bye");
+
+        //Same object
+        assertEquals(commentOne, commentOne);
+
+        //Different object but same content
+        assertEquals(commentOne, commentOneDuplicated);
+
+        //One Comment and one non-Comment object
+        assertNotEquals(commentOne, "hello");
+
+        //Comment objects with different comment content
+        assertNotEquals(commentOne, commentTwo);
+    }
+
+    @Test
+    public void checkStringRepresentation() {
+        Comment commentOne = new Comment("hello");
+        assertEquals(commentOne.toString(), "[hello]");
+    }
+
 }

--- a/src/test/java/seedu/address/model/internship/CommentTest.java
+++ b/src/test/java/seedu/address/model/internship/CommentTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.internship;
+
+public class CommentTest {
+}

--- a/src/test/java/seedu/address/model/internship/InternshipTest.java
+++ b/src/test/java/seedu/address/model/internship/InternshipTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.internship;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_GOOGLE;
@@ -83,6 +84,10 @@ public class InternshipTest {
 
         // different date -> returns false
         editedApple = new InternshipBuilder(APPLE).withDate(VALID_DATE_GOOGLE).build();
+        assertFalse(APPLE.equals(editedApple));
+
+        // different comment -> returns false
+        editedApple = new InternshipBuilder(APPLE).withComment(VALID_COMMENT_GOOGLE).build();
         assertFalse(APPLE.equals(editedApple));
 
         // different tags -> returns false

--- a/src/test/java/seedu/address/storage/JsonAdaptedInternshipTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedInternshipTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Role;
@@ -22,12 +23,14 @@ public class JsonAdaptedInternshipTest {
     private static final String INVALID_ROLE = "Software E!gineer";
     private static final String INVALID_STATUS = " ";
     private static final String INVALID_DATE = "1st March 2023";
+    private static final String INVALID_COMMENT = "";
     private static final String INVALID_TAG = "";
 
     private static final String VALID_COMPANY_NAME = GOOGLE.getCompanyName().toString();
     private static final String VALID_ROLE = GOOGLE.getRole().toString();
     private static final String VALID_STATUS = GOOGLE.getStatus().toString();
     private static final String VALID_DATE = GOOGLE.getDate().toString();
+    private static final String VALID_COMMENT = GOOGLE.getComment().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = GOOGLE.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,7 +44,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidCompanyName_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(INVALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(INVALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, VALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = CompanyName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -49,7 +53,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullCompanyName_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new
-                JsonAdaptedInternship(null, VALID_ROLE, VALID_STATUS, VALID_DATE, VALID_TAGS);
+                JsonAdaptedInternship(null, VALID_ROLE, VALID_STATUS, VALID_DATE, VALID_COMMENT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CompanyName.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -57,7 +61,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, INVALID_ROLE, VALID_STATUS, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, INVALID_ROLE, VALID_STATUS, VALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -65,7 +70,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullRole_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, null, VALID_STATUS, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, null, VALID_STATUS, VALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Role.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -73,7 +79,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidStatus_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, INVALID_STATUS, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, INVALID_STATUS, VALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = Status.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -81,7 +88,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullStatus_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, null, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, null, VALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -89,7 +97,8 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, INVALID_DATE, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, INVALID_DATE, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -97,8 +106,18 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, null, VALID_TAGS);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, null, VALID_COMMENT,
+                        VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidComment_throwsIllegalValueException() {
+        JsonAdaptedInternship internship =
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, VALID_DATE, INVALID_COMMENT,
+                        VALID_TAGS);
+        String expectedMessage = Comment.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
 
@@ -107,7 +126,8 @@ public class JsonAdaptedInternshipTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedInternship internship =
-                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, VALID_DATE, invalidTags);
+                new JsonAdaptedInternship(VALID_COMPANY_NAME, VALID_ROLE, VALID_STATUS, VALID_DATE, VALID_COMMENT,
+                        invalidTags);
         assertThrows(IllegalValueException.class, internship::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/EditInternshipDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditInternshipDescriptorBuilder.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditInternshipDescriptor;
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -36,6 +37,7 @@ public class EditInternshipDescriptorBuilder {
         descriptor.setRole(internship.getRole());
         descriptor.setStatus(internship.getStatus());
         descriptor.setDate(internship.getDate());
+        descriptor.setComment(internship.getComment());
         descriptor.setTags(internship.getTags());
     }
 
@@ -70,6 +72,16 @@ public class EditInternshipDescriptorBuilder {
         descriptor.setDate(new Date(date));
         return this;
     }
+
+    /**
+     * Sets the {@code Comment} of the {@code EditInternshipDescriptor} that we are building.
+     */
+    public EditInternshipDescriptorBuilder withComment(String comment) {
+        descriptor.setComment(new Comment(comment));
+        return this;
+    }
+
+
 
     /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditInternshipDescriptor}

--- a/src/test/java/seedu/address/testutil/InternshipBuilder.java
+++ b/src/test/java/seedu/address/testutil/InternshipBuilder.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.model.internship.Comment;
 import seedu.address.model.internship.CompanyName;
 import seedu.address.model.internship.Date;
 import seedu.address.model.internship.Internship;
@@ -20,11 +21,13 @@ public class InternshipBuilder {
     public static final String DEFAULT_ROLE = "Mobile Developer";
     public static final String DEFAULT_STATUS = "interview";
     public static final String DEFAULT_DATE = "2023-02-01";
+    public static final String DEFAULT_COMMENT = "NA";
 
     private CompanyName companyName;
     private Role role;
     private Status status;
     private Date date;
+    private Comment comment;
     private Set<Tag> tags;
 
     /**
@@ -74,6 +77,20 @@ public class InternshipBuilder {
     }
 
     /**
+     * Sets the {@code Comment} of the {@code Internship} that we are building.
+     */
+    public InternshipBuilder withComment(String comment) {
+        if (comment != null) {
+            this.comment = new Comment(comment);
+        } else {
+            this.comment = new Comment("NA");
+        }
+        return this;
+    }
+
+
+
+    /**
      * Sets the {@code Role} of the {@code Internship} that we are building.
      */
     public InternshipBuilder withRole(String role) {
@@ -90,7 +107,7 @@ public class InternshipBuilder {
     }
 
     public Internship build() {
-        return new Internship(companyName, role, status, date, tags);
+        return new Internship(companyName, role, status, date, comment, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/InternshipBuilder.java
+++ b/src/test/java/seedu/address/testutil/InternshipBuilder.java
@@ -21,7 +21,7 @@ public class InternshipBuilder {
     public static final String DEFAULT_ROLE = "Mobile Developer";
     public static final String DEFAULT_STATUS = "interview";
     public static final String DEFAULT_DATE = "2023-02-01";
-    public static final String DEFAULT_COMMENT = "NA";
+    public static final String DEFAULT_COMMENT = "I love Apple!";
 
     private CompanyName companyName;
     private Role role;
@@ -38,6 +38,7 @@ public class InternshipBuilder {
         role = new Role(DEFAULT_ROLE);
         status = new Status(DEFAULT_STATUS);
         date = new Date(DEFAULT_DATE);
+        comment = new Comment(DEFAULT_COMMENT);
         tags = new HashSet<>();
     }
 
@@ -49,6 +50,7 @@ public class InternshipBuilder {
         role = internshipToCopy.getRole();
         status = internshipToCopy.getStatus();
         date = internshipToCopy.getDate();
+        comment = internshipToCopy.getComment();
         tags = new HashSet<>(internshipToCopy.getTags());
     }
 

--- a/src/test/java/seedu/address/testutil/InternshipUtil.java
+++ b/src/test/java/seedu/address/testutil/InternshipUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -34,6 +35,7 @@ public class InternshipUtil {
         sb.append(PREFIX_ROLE + internship.getRole().fullRole + " ");
         sb.append(PREFIX_STATUS + internship.getStatus().toString() + " ");
         sb.append(PREFIX_DATE + internship.getDate().fullDate + " ");
+        sb.append(PREFIX_COMMENT + internship.getComment().commentContent + " ");
         internship.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -50,6 +52,8 @@ public class InternshipUtil {
         descriptor.getRole().ifPresent(role -> sb.append(PREFIX_ROLE).append(role.fullRole).append(" "));
         descriptor.getStatus().ifPresent(status -> sb.append(PREFIX_STATUS).append(status.toString()).append(" "));
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.fullDate).append(" "));
+        descriptor.getComment().ifPresent(comment -> sb.append(PREFIX_COMMENT).append(comment.commentContent).
+                append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/InternshipUtil.java
+++ b/src/test/java/seedu/address/testutil/InternshipUtil.java
@@ -52,8 +52,8 @@ public class InternshipUtil {
         descriptor.getRole().ifPresent(role -> sb.append(PREFIX_ROLE).append(role.fullRole).append(" "));
         descriptor.getStatus().ifPresent(status -> sb.append(PREFIX_STATUS).append(status.toString()).append(" "));
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.fullDate).append(" "));
-        descriptor.getComment().ifPresent(comment -> sb.append(PREFIX_COMMENT).append(comment.commentContent).
-                append(" "));
+        descriptor.getComment().ifPresent(comment -> sb.append(PREFIX_COMMENT).append(comment.commentContent)
+                .append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/address/testutil/TypicalInternships.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_NAME_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPLE;
@@ -8,8 +10,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_GOOGLE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_APPLE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BACK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRONT;
 

--- a/src/test/java/seedu/address/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/address/testutil/TypicalInternships.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_GOOGLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMMENT_GOOGLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BACK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRONT;
 
@@ -27,6 +29,7 @@ public class TypicalInternships {
             .withRole("Cloud Architect")
             .withStatus("assessment")
             .withDate("2023-02-01")
+            .withComment("I love Amazon!")
             .withTags("aws", "back").build();
     public static final Internship FOODPANDA = new InternshipBuilder().withCompanyName("Food Panda")
             .withRole("Back end Developer")
@@ -44,6 +47,7 @@ public class TypicalInternships {
             .withRole("Game Client Developer")
             .withStatus("interview")
             .withDate("2023-02-05")
+            .withComment("I love Riot Games!")
             .withTags("game", "developer").build();
 
     public static final Internship SAMSUNG = new InternshipBuilder().withCompanyName("Samsung")
@@ -54,6 +58,7 @@ public class TypicalInternships {
             .withRole("Game Designer")
             .withStatus("new")
             .withDate("2023-02-07")
+            .withComment("I love Supercell Games!")
             .withTags("design", "game").build();
 
 
@@ -72,11 +77,13 @@ public class TypicalInternships {
             .withRole(VALID_ROLE_APPLE)
             .withStatus(VALID_STATUS_APPLE)
             .withDate(VALID_DATE_APPLE)
+            .withComment(VALID_COMMENT_APPLE)
             .withTags(VALID_TAG_FRONT).build();
     public static final Internship GOOGLE = new InternshipBuilder().withCompanyName(VALID_COMPANY_NAME_GOOGLE)
             .withRole(VALID_ROLE_GOOGLE)
             .withStatus(VALID_STATUS_GOOGLE)
             .withDate(VALID_DATE_GOOGLE)
+            .withComment(VALID_COMMENT_GOOGLE)
             .withTags(VALID_TAG_FRONT, VALID_TAG_BACK)
             .build();
 

--- a/src/test/java/seedu/address/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/address/testutil/TypicalInternships.java
@@ -34,14 +34,17 @@ public class TypicalInternships {
     public static final Internship FOODPANDA = new InternshipBuilder().withCompanyName("Food Panda")
             .withRole("Back end Developer")
             .withStatus("assessment")
+            .withComment("I love Food Panda!")
             .withDate("2023-02-02").build();
     public static final Internship GOLDMAN = new InternshipBuilder().withCompanyName("Goldman")
             .withRole("Cyber Security Analyst")
             .withStatus("offered")
+            .withComment("I love Goldman!")
             .withDate("2023-02-03").build();
     public static final Internship GRAB = new InternshipBuilder().withCompanyName("Grab")
             .withRole("Front end Engineer")
             .withStatus("rejected")
+            .withComment("I love Grab!")
             .withDate("2023-02-04").build();
     public static final Internship RIOTGAMES = new InternshipBuilder().withCompanyName("Riot Games")
             .withRole("Game Client Developer")
@@ -53,7 +56,9 @@ public class TypicalInternships {
     public static final Internship SAMSUNG = new InternshipBuilder().withCompanyName("Samsung")
             .withRole("Android Developer")
             .withStatus("applied")
-            .withDate("2023-02-06").build();
+            .withDate("2023-02-06")
+            .withComment("I love Samsung!").build();
+
     public static final Internship SUPERCELLGAMES = new InternshipBuilder().withCompanyName("Supercell Games")
             .withRole("Game Designer")
             .withStatus("new")
@@ -72,7 +77,7 @@ public class TypicalInternships {
             .withStatus("interview")
             .withDate("2023-02-09").build();
 
-    // Manually added - Person's details found in {@code CommandTestUtil}
+    // Manually added - Internship's details found in {@code CommandTestUtil}
     public static final Internship APPLE = new InternshipBuilder().withCompanyName(VALID_COMPANY_NAME_APPLE)
             .withRole(VALID_ROLE_APPLE)
             .withStatus(VALID_STATUS_APPLE)

--- a/src/test/java/seedu/address/ui/InternshipDetailsCardTest.java
+++ b/src/test/java/seedu/address/ui/InternshipDetailsCardTest.java
@@ -24,6 +24,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
 import seedu.address.model.internship.Internship;
 import seedu.address.testutil.InternshipBuilder;
 import seedu.address.testutil.TypicalInternships;
@@ -154,11 +155,13 @@ public class InternshipDetailsCardTest extends GuiUnitTest {
         Label internshipDate = (Label) internshipRegion.lookup("#date");
         Label internshipStatus = (Label) internshipRegion.lookup("#statusLabel");
         String expectedDateLabel = InternshipCard.getDateLabel(internship.getStatus().toString());
+        Text comment = (Text) internshipRegion.lookup("#comment");
         ObservableList<Node> internshipNodeTags = ((FlowPane) internshipRegion.lookup("#tags")).getChildren();
         assertEquals(companyName.getText(), internship.getCompanyName().toString());
         assertEquals(internshipRoleLabel.getText(), ROLE_LABEL + internship.getRole().toString());
 
         assertEquals(internshipDate.getText(), expectedDateLabel + internship.getDate().toString());
+        assertEquals("[" + comment.getText() + "]", internship.getComment().toString());
         assertEquals(internshipStatus.getText(), internship.getStatus().toString().toUpperCase());
         assertIterableEquals(internshipNodeTags.stream().map(node -> ((Label) node).getText()).sorted()
                 .collect(Collectors.toList()), internship.getTags().stream().sorted().collect(Collectors.toList()));


### PR DESCRIPTION
### Main Changes
1. Add feature to allow users to enter an optional `comment` field in the `add` command, using `c/Comment`. Note that there is no restrictions for comments.
2. Able to edit comment via `edit` command
3. Able to view comment of an internship entry in the right panel when using the `view` command
4. Include relevant tests
5. Made right panel responsive to `add`, `edit` and `delete` commands. This means when user adds/edit/deletes a particular internship, the right panel's information will be updated accordingly.

![image](https://user-images.githubusercontent.com/86542359/226317723-36f0ecf2-4234-4e15-ab14-40d21563b98e.png)

### Issues
This PR fixes #66.