### PR TITLE
Fix right panel not resetting after clear

### DIFF
--- a/src/main/java/seedu/internship/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/internship/logic/commands/ClearCommand.java
@@ -18,6 +18,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setInternBuddy(new InternBuddy());
+        model.updateSelectedInternship(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
Right panel does not reset after a clear command. For example, if user runs `view 1` then `clear`, the right panel will still show an internship entry, not the introductory messages.

Let's reset the internship panel after a clear command.