### PR TITLE
UI Overflow Bug Fix

### DIFF
--- a/src/main/java/seedu/internship/ui/InternshipDetailsCard.java
+++ b/src/main/java/seedu/internship/ui/InternshipDetailsCard.java
@@ -46,10 +46,10 @@ public class InternshipDetailsCard extends UiPart<Region> {
     @FXML
     private VBox cardPane;
     @FXML
-    private Label companyName;
+    private Text companyName;
 
     @FXML
-    private Label role;
+    private Text role;
     @FXML
     private Label date;
     @FXML

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -113,7 +113,7 @@
 
 .list-cell:filled:selected #cardPane {
     -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
+    -fx-border-width: 0;
 }
 
 .list-cell .label {

--- a/src/main/resources/view/InternshipDetailsCard.fxml
+++ b/src/main/resources/view/InternshipDetailsCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox fx:id="cardPane" prefHeight="232.0" prefWidth="300.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="cardPane" prefHeight="317.0" prefWidth="338.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane>
          <columnConstraints>
@@ -31,11 +31,14 @@
                <children>
                   <HBox alignment="CENTER_LEFT" prefHeight="51.0" spacing="5">
                      <children>
-                        <Label fx:id="companyName" styleClass="whiteCompanyNameLabel" text="\$first">
+                        <Text fx:id="companyName" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="\$first" wrappingWidth="307.1015625">
                            <HBox.margin>
                               <Insets bottom="10.0" left="10.0" top="30.0" />
                            </HBox.margin>
-                        </Label>
+                           <font>
+                              <Font name="Segoe UI" size="20.0" />
+                           </font>
+                        </Text>
                      </children>
                   </HBox>
                   <FlowPane fx:id="tags">
@@ -43,11 +46,14 @@
                         <Insets left="10.0" />
                      </VBox.margin>
                   </FlowPane>
-                  <Label fx:id="role" styleClass="whiteLabel" text="\$role">
+                  <Text fx:id="role" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="whiteLabel" text="\$role" wrappingWidth="307.1015625">
                      <VBox.margin>
                         <Insets left="10.0" top="10.0" />
                      </VBox.margin>
-                  </Label>
+                     <font>
+                        <Font name="Segoe UI" size="16.0" />
+                     </font>
+                  </Text>
                   <Label fx:id="date" styleClass="whiteLabel" text="\$date">
                      <VBox.margin>
                         <Insets left="10.0" top="10.0" />
@@ -101,7 +107,7 @@
             </HBox>
             <Text fx:id="tips" strokeType="OUTSIDE" strokeWidth="0.0" text="\$tips" wrappingWidth="267.13671875">
                <VBox.margin>
-                  <Insets bottom="10.0" top="10.0" />
+                  <Insets bottom="30.0" top="10.0" />
                </VBox.margin>
             </Text>
          </children>

--- a/src/main/resources/view/InternshipDetailsCard.fxml
+++ b/src/main/resources/view/InternshipDetailsCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox fx:id="cardPane" prefHeight="317.0" prefWidth="338.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="cardPane" prefHeight="317.0" prefWidth="338.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane>
          <columnConstraints>

--- a/src/main/resources/view/InternshipListCard.fxml
+++ b/src/main/resources/view/InternshipListCard.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/InternshipListCard.fxml
+++ b/src/main/resources/view/InternshipListCard.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -27,11 +27,11 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="companyName" styleClass="cell_big_label" text="\$first" />
+        <Label fx:id="companyName" styleClass="cell_big_label" text="\$first" wrapText="true" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
-      <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
+      <Label fx:id="role" styleClass="cell_small_label" text="\$role" wrapText="true" />
+      <Label fx:id="date" styleClass="cell_small_label" text="\$date" wrapText="true" />
     </VBox>
       <VBox alignment="TOP_RIGHT" prefHeight="102.0" prefWidth="130.0" GridPane.columnIndex="1">
          <children>

--- a/src/test/java/seedu/internship/ui/InternshipDetailsCardTest.java
+++ b/src/test/java/seedu/internship/ui/InternshipDetailsCardTest.java
@@ -159,15 +159,15 @@ public class InternshipDetailsCardTest extends GuiUnitTest {
         //Reused from teammate potty10 where he modified the code from
         //https://github.com/AY2223S1-CS2103T-W17-4/tp/blob/master/src/test/java/seedu/phu/ui/InternshipCardTest.java
         Region internshipRegion = internshipDetailCard.getRoot();
-        Label companyName = (Label) internshipRegion.lookup("#companyName");
-        Label internshipRoleLabel = (Label) internshipRegion.lookup("#role");
+        Text companyName = (Text) internshipRegion.lookup("#companyName");
+        Text internshipRoleText = (Text) internshipRegion.lookup("#role");
         Label internshipDate = (Label) internshipRegion.lookup("#date");
         Label internshipStatus = (Label) internshipRegion.lookup("#statusLabel");
         String expectedDateLabel = InternshipCard.getDateLabel(internship.getStatus().toString());
         Text comment = (Text) internshipRegion.lookup("#comment");
         ObservableList<Node> internshipNodeTags = ((FlowPane) internshipRegion.lookup("#tags")).getChildren();
         assertEquals(companyName.getText(), internship.getCompanyName().toString());
-        assertEquals(internshipRoleLabel.getText(), ROLE_LABEL + internship.getRole().toString());
+        assertEquals(internshipRoleText.getText(), ROLE_LABEL + internship.getRole().toString());
 
         assertEquals(internshipDate.getText(), expectedDateLabel + internship.getDate().toString());
         assertEquals("[" + comment.getText() + "]", internship.getComment().toString());


### PR DESCRIPTION
### Problem
Current UI leads to the following details being truncated even though the details were operating within the limits specified in InternBuddy (e.g. max 50 characters for `CompanyName`).

This is a bug fix because the inputs are not considered extreme where they work under the constraints that we have set. Instead of changing the constraints which is a feature tweak, we would fix the UI because the UI does not work as intended.

![image](https://user-images.githubusercontent.com/86542359/229443160-2363bbef-e30a-4811-bbbb-898f686381d3.png)

### Fix
- Made overflowing text wrap-around instead
- Removed border around a selected `InternshipListCard` because it causes the text to keep moving when wrapping is enabled
- Updated tests accordingly

![image](https://user-images.githubusercontent.com/86542359/229443841-3b88d82d-e0ce-4bd8-81ce-d53e6261168f.png)

### Issues
This PR closes #164 and #171.

